### PR TITLE
minimum-release-ageの値変更

### DIFF
--- a/.pnpmrc
+++ b/.pnpmrc
@@ -1,2 +1,2 @@
 ignore-scripts=false
-minimum-release-age=1440
+minimum-release-age=2880


### PR DESCRIPTION
@h1fukuda 
## 背景・経緯
minimumReleaseAge設定の有無がプロジェクトにより異なっており、設定値も統一されていない。

<!--
  suggest
  関連するスレッドのやり取り, 仕様, 関連issue, その他伝えたい背景情報があれば記載してください
-->
<!--
  例)
  close #
  関連するやり取り: {kintoneのリンク}
-->

## 概要

minimumReleaseAgeの設定をプロジェクト全体で2880（２日）に統一する
https://github.com/orgs/Cybozu-SD/projects/8/views/26?pane=issue&itemId=164261726&issue=Cybozu-SD%7CSiamese%7C400

<!--
  must
  このPRで実装した機能や修正内容の概要を簡潔に説明してください
-->

## やったこと・変更内容
pnpm-workflow.yamlの設定変更

<!--
  must
  具体的な変更内容を箇条書きで記載してください
-->

## やらないこと

<!--
  optional
  このPRと関連する課題であえて取り組まないもの(レビュアーが知りたいであろう情報)があれば記載してください
-->

## 検証内容

設定変更後、node_modulesを削除して`pnpm i --frozen-lockfile`を実行しパッケージをインストールできること

<!--
  suggest
  関連するIssue番号を記載してください
-->
<!--
  例)
  - [ ] `pnpm test`を実行
  - [ ] mypage-test環境で以下内容を確認 (結果はスクリーンショットに記載)
-->